### PR TITLE
Set default plugin name in template

### DIFF
--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -13,6 +13,8 @@
  */
 #}
 
+{% set pluginName = pluginName ?? 'Search Assistant' %}
+
 {% requirePermission 'searchAssistant:viewFullHistory' %}
 
 {% extends "_layouts/elementindex" %}


### PR DESCRIPTION
Ensures a default value for the plugin name if none is provided, improving user experience by preventing potential display issues.

quick fix for 

> Twig Runtime Error – Twig\Error\RuntimeError
> Variable "pluginName" does not exist.
> 1. in /var/www/html/vendor/jrrdnx/craft-search-assistant/src/templates/index.twig
