### PR TITLE
Refactor query logic for popular searches

### DIFF
--- a/src/services/HistoryService.php
+++ b/src/services/HistoryService.php
@@ -152,37 +152,19 @@ class HistoryService extends Component
      */
     public function getPopularSearches(array $options = [])
     {
-        $sql = "
-            SELECT
-                `keywords`,
-                SUM(searchCount) AS `searchCount`
-            FROM
-                ".HistoryRecord::tableName()." AS `history`,
-                ".Table::ELEMENTS." AS `elements`
-            WHERE
-                `siteId` = ".Craft::$app->sites->getCurrentSite()->id."
-                AND
-                `history`.`id` = `elements`.`id`
-                AND
-                `elements`.`enabled` = 1
-        ";
+
+        $query = HistoryElement::find()
+            ->siteId(Craft::$app->sites->getCurrentSite()->id)
+            ->popularSearches(true)
+            ->numResults(true)
+            ->limit($options['limit'] ?? 5);
+
 
         if (!empty($options['pageUrl'])) {
-            $sql .= "AND `history`.`pageUrl` = '".explode('?', $options['pageUrl'])[0]."'";
+            $query->pageUrl(explode('?', $options['pageUrl'])[0]);
         }
 
-        $sql .= "
-                AND
-                `history`.`numResults` > 0
-            GROUP BY
-                `keywords`
-            ORDER BY
-                `searchCount` DESC
-            LIMIT
-                ".($options['limit'] ?? 5);
-
-        $query = Craft::$app->getDb()->createCommand()->setSql($sql);
-
-        return $query->queryAll();
+        return $query->all();
     }
+
 }


### PR DESCRIPTION
There was an error on popular search query because of MySQL’s “only_full_group_by” mode

Seeing as the `HistoryElementQuery` class, already handles the proper grouping and aggregation for popular searches I used this instead 




> SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'xxxxx.elements.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by The SQL being executed was: SELECT elements.id, elements.canonicalId, elements.fieldLayoutId, elements.uid, elements.enabled, elements.archived, elements.dateLastMerged, elements.dateCreated, elements.dateUpdated, elements_sites.id AS siteSettingsId, elements_sites.slug, elements_sites.siteId, elements_sites.uri, elements_sites.enabled AS enabledForSite, search_assistant_history.keywords, SUM(search_assistant_history.searchCount) AS searchCount, MAX(search_assistant_history.lastSearched) AS lastSearched, MAX(search_assistant_history.pageUrl) AS pageUrl, MAX(search_assistant_history.numResults) AS numResults FROM (SELECT elements.id AS elementsId, elements_sites.id AS elementsSitesId FROM elements elements INNER JOIN search_assistant_history search_assistant_history ON search_assistant_history.id = elements.id INNER JOIN elements_sites elements_sites ON elements_sites.elementId = elements.id WHERE (search_assistant_history.siteId=1) AND (numResults > 0) AND (elements.archived=FALSE) AND (elements.dateDeleted IS NULL) AND (elements.draftId IS NULL) AND (elements.revisionId IS NULL) LIMIT 100) subquery INNER JOIN elements elements ON elements.id = subquery.elementsId INNER JOIN elements_sites elements_sites ON elements_sites.id = subquery.elementsSitesId INNER JOIN search_assistant_history search_assistant_history ON search_assistant_history.id = subquery.elementsId GROUP BY search_assistant_history.keywords ORDER BY searchCount DESC